### PR TITLE
Misc fixes and LDAPS support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,10 @@ tokio-service = "0.1"
 tokio-tls = { version = "0.1.2", features = [ "tokio-proto" ] }
 
 [dependencies.asnom]
-path = "../asnom"
+git = "https://github.com/dequbed/asnom.git"
 
 [dependencies.rfc4515]
-path = "../rfc4515"
+git = "https://github.com/dequbed/rfc4515.git"
 
 [dev-dependencies]
 env_logger = "0.4.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,8 @@ tokio-core = "0.1"
 tokio-proto = "0.1"
 tokio-service = "0.1"
 
-asnom = { git = "https://github.com/dequbed/asnom.git" }
-rfc4515 = { git = "https://github.com/dequbed/rfc4515.git" }
+asnom = { path = "../asnom" }
+rfc4515 = { path = "../rfc4515" }
+
+[dev-dependencies]
+env_logger = "0.4.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,27 +1,29 @@
 [package]
-name = "ldap"
-version = "0.3.0"
 authors = ["Gregor Reitzenstein <dean4devil@paranoidlabs.org>"]
-
 description = "Pure Rust LDAP Implementation (Not abandonware anymore!)"
-repository = "https://github.com/dequbed/rust-ldap"
 documentation = "https://docs.rs/ldap"
-readme = "README.md"
-
 keywords = ["ldap", "libldap"]
-
 license = "MIT/Apache-2.0"
+name = "ldap"
+readme = "README.md"
+repository = "https://github.com/dequbed/rust-ldap"
+version = "0.3.0"
 
 [dependencies]
-log = "0.3.6"
-futures = "0.1"
 byteorder = "1.0.0"
+futures = "0.1"
+log = "0.3.6"
+native-tls = "0.1.1"
 tokio-core = "0.1"
 tokio-proto = "0.1"
 tokio-service = "0.1"
+tokio-tls = { version = "0.1.2", features = [ "tokio-proto" ] }
 
-asnom = { path = "../asnom" }
-rfc4515 = { path = "../rfc4515" }
+[dependencies.asnom]
+path = "../asnom"
+
+[dependencies.rfc4515]
+path = "../rfc4515"
 
 [dev-dependencies]
 env_logger = "0.4.2"

--- a/examples/search.rs
+++ b/examples/search.rs
@@ -15,7 +15,8 @@ pub fn main() {
                                ldap::Scope::WholeSubtree,
                                ldap::DerefAliases::Never,
                                false,
-                               "(objectClass=*)".to_string());
+                               "(objectClass=*)".to_string(),
+                               vec![]);
         println!("Search result: {:?}", res2);
     } else {
         println!("Bind failed! :(");

--- a/examples/search_async.rs
+++ b/examples/search_async.rs
@@ -17,7 +17,8 @@ pub fn main() {
                                   ldap::Scope::WholeSubtree,
                                   ldap::DerefAliases::Never,
                                   false,
-                                  "(objectClass=*)".to_string()));
+                                  "(objectClass=*)".to_string(),
+                                  vec![]));
 
     println!("Search Results: {:?}", search_results)
 }

--- a/src/ldap.rs
+++ b/src/ldap.rs
@@ -1,16 +1,15 @@
 use std::io;
-use std::net::SocketAddr;
+use std::iter;
+use std::net::{SocketAddr, ToSocketAddrs};
 
 use asnom::structures::Tag;
-
-use futures::Future;
-
+use futures::{future, Future};
+use native_tls::TlsConnector;
 use tokio_core::reactor::Handle;
-
-use tokio_service::Service;
-
 use tokio_proto::util::client_proxy::ClientProxy;
 use tokio_proto::TcpClient;
+use tokio_service::Service;
+use tokio_tls::proto::Client as TlsClient;
 
 use protocol::LdapProto;
 use service::{LdapMessage, TokioMessage};
@@ -24,6 +23,27 @@ impl Ldap {
         Box<Future<Item = Ldap, Error = io::Error>> {
         let ret = TcpClient::new(LdapProto)
             .connect(addr, handle)
+            .map(|client_proxy| {
+                let typemap = ClientTypeMap { inner: client_proxy };
+                Ldap { inner: typemap }
+            });
+        Box::new(ret)
+    }
+
+    pub fn connect_ssl(addr: &str, handle: &Handle) ->
+        Box<Future<Item = Ldap, Error = io::Error>> {
+        if addr.parse::<SocketAddr>().ok().is_some() {
+            return Box::new(future::err(io::Error::new(io::ErrorKind::Other, "SSL connection must be by hostname")));
+        }
+        let sockaddr = addr.to_socket_addrs().unwrap_or(vec![].into_iter()).next();
+        if sockaddr.is_none() {
+            return Box::new(future::err(io::Error::new(io::ErrorKind::Other, "no addresses found")));
+        }
+        let wrapper = TlsClient::new(LdapProto,
+            TlsConnector::builder().expect("tls_builder").build().expect("connector"),
+            addr.split(':').next().expect("hostname"));
+        let ret = TcpClient::new(wrapper)
+            .connect(&sockaddr.unwrap(), handle)
             .map(|client_proxy| {
                 let typemap = ClientTypeMap { inner: client_proxy };
                 Ldap { inner: typemap }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,10 +2,11 @@ extern crate asnom;
 extern crate rfc4515;
 
 extern crate futures;
+extern crate native_tls;
 extern crate tokio_core;
 extern crate tokio_proto;
 extern crate tokio_service;
-
+extern crate tokio_tls;
 extern crate byteorder;
 
 #[macro_use]

--- a/src/search.rs
+++ b/src/search.rs
@@ -96,7 +96,8 @@ impl Ldap {
                     scope: Scope,
                     deref: DerefAliases,
                     typesonly: bool,
-                    filter: String) ->
+                    filter: String,
+                    attrs: Vec<String>) ->
         Box<Future<Item = Vec<SearchEntry>, Error = io::Error>> {
         let req = Tag::Sequence(Sequence {
             id: 3,
@@ -128,6 +129,8 @@ impl Ldap {
                    }),
                    parse(&filter).unwrap(),
                    Tag::Sequence(Sequence {
+                       inner: attrs.into_iter().map(|s|
+                            Tag::OctetString(OctetString { inner: s.into_bytes(), ..Default::default() })).collect(),
                        .. Default::default()
                    })
             ],

--- a/src/service.rs
+++ b/src/service.rs
@@ -17,6 +17,14 @@ pub struct LdapMessageStream {
     inner: Body<Tag, io::Error>,
 }
 
+impl LdapMessageStream {
+    pub fn empty() -> LdapMessageStream {
+        LdapMessageStream {
+            inner: Body::empty()
+        }
+    }
+}
+
 impl Stream for LdapMessageStream {
     type Item = Tag;
     type Error = io::Error;

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -32,7 +32,8 @@ impl LdapSync {
                   scope: Scope,
                   deref: DerefAliases,
                   typesonly: bool,
-                  filter: String) -> io::Result<Vec<SearchEntry>> {
-        self.core.run(self.inner.search(base, scope, deref, typesonly, filter))
+                  filter: String,
+                  attrs: Vec<String>) -> io::Result<Vec<SearchEntry>> {
+        self.core.run(self.inner.search(base, scope, deref, typesonly, filter, attrs))
     }
 }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -12,13 +12,12 @@ pub struct LdapSync {
 }
 
 impl LdapSync {
-    pub fn connect(addr: &str) -> Result<LdapSync, io::Error> {
+    pub fn connect(addr: &SocketAddr) -> Result<LdapSync, io::Error> {
         // TODO better error handling
         let mut core = Core::new().unwrap();
         let handle = core.handle();
 
-        let addr: SocketAddr = addr.parse().map_err(|_e| io::Error::new(io::ErrorKind::Other, "error parsing address"))?;
-        let ldapfut = Ldap::connect(&addr, &handle);
+        let ldapfut = Ldap::connect(addr, &handle);
         let ldap = try!(core.run(ldapfut));
 
         Ok(LdapSync { inner: ldap, core: core })


### PR DESCRIPTION
The search operation would hang if the server returned just a `SearchResultDone` message, which can happen under various circumstances. This is now fixed.

Attribute lists can now be specified in searches.

LDAPS is supported, with the following caveats:
* The server cert must be valid, the CA verifiable by the client, and hostname verification must pass. Self-signed certs are not supported. (Those are dictated by __native-tls__, which __tokio-tls__ uses as the TLS library.)
* For the above to work, a TLS connection (obtained by `connect_ssl()`, named so as to follow the ancient LDAP nomenclature) must be requested by hostname, not IP address.
* The hostname is resolved synchronously by `std::net::ToSocketAddrs`.